### PR TITLE
160-add-demand-option.patch

### DIFF
--- a/160-add-demand-option.patch
+++ b/160-add-demand-option.patch
@@ -1,0 +1,10 @@
+--- a/package/openwrt/net/xl2tpd/files/l2tp.sh
++++ b/package/openwrt/net/xl2tpd/files/l2tp.sh
+@@ -14,6 +14,7 @@ proto_l2tp_init_config() {
+        proto_config_add_string "keepalive"
+        proto_config_add_string "pppd_options"
+        proto_config_add_boolean "ipv6"
++      proto_config_add_int "demand"
+        proto_config_add_int "mtu"
+        proto_config_add_string "server"
+        available=1


### PR DESCRIPTION
json_get_vars ipv6 demand keepalive username password pppd_options 

the above line in l2tp.sh fails to read demand option and whenever user changes only demand option (idle time value) xl2tp dameon is not notified.
